### PR TITLE
New features for scopes

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,7 @@ end
 appraise "5.0" do
   gem "rails", "~> 5.0.0"
 end
+
+appraise "5.1" do
+  gem "rails", "~> 5.1.0"
+end

--- a/spec/dummy/app/controllers/block_users_controller.rb
+++ b/spec/dummy/app/controllers/block_users_controller.rb
@@ -1,0 +1,16 @@
+class BlockUsersController < ApplicationController
+  before_action :set_name
+
+  autocomplete(:user, :email) { |r| if @name then r.where(last_name: @name) else r end }  
+
+  def show
+  end
+
+  private
+  
+  def set_name
+    if params[:name]
+      @name = params[:name]
+    end
+  end
+end

--- a/spec/dummy/app/controllers/scoped_users_controller.rb
+++ b/spec/dummy/app/controllers/scoped_users_controller.rb
@@ -1,0 +1,6 @@
+class ScopedUsersController < ApplicationController
+  autocomplete :user, :email, scopes: [[:has_lastname, 'MyScopeParam']]
+
+  def show
+  end
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ActiveRecord::Base
+  scope :has_lastname, ->(name) { where(last_name: name) }
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get 'users/show'
   get 'users/autocomplete_user_email'
+  get 'scoped_users/autocomplete_user_email'
+  get 'block_users/:name/autocomplete_user_email', to: 'block_users#autocomplete_user_email', as: :block_users_autocomplete_user_email
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/requests/block_rests_spec.rb
+++ b/spec/requests/block_rests_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'support/request_helpers'
+
+describe 'blocks' do
+  context 'with 2 users in database' do
+    before(:each) do
+      @user1 = create(:user, :with_full_name, last_name: 'MyBlockParam')
+      @user2 = create(:user, :with_full_name)
+    end
+
+    context 'scope with argument' do
+      before :each do
+        do_get block_users_autocomplete_user_email_path(name: 'MyBlockParam'),
+               params: { term: 'user' }
+      end
+
+      it 'is successful' do
+        expect(response).to be_success
+      end
+
+      it 'returns only first user' do
+        expect(json.size).to eq(1)
+      end
+    end
+  end
+
+end

--- a/spec/requests/scoped_requests_spec.rb
+++ b/spec/requests/scoped_requests_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'support/request_helpers'
+
+describe 'scopes' do
+  context 'with 2 users in database' do
+    before(:each) do
+      @user1 = create(:user, :with_full_name, last_name: 'MyScopeParam')
+      @user2 = create(:user, :with_full_name)
+    end
+
+    context 'scope with argument' do
+      before :each do
+        do_get scoped_users_autocomplete_user_email_path,
+               params: { term: 'user' }
+      end
+
+      it 'is successful' do
+        expect(response).to be_success
+      end
+
+      it 'returns only first user' do
+        expect(json.size).to eq(1)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This adds two new features:

1. Scopes can be defines using (constant) parameters:
If a model has defines a scope with parameters e.g.
`scope :has_lastname, ->(name) { where(last_name: name) }`
one can use an array of array for scopes to pass additional arguments like 
`autocomplete :user, :email, scopes: [[:has_lastname, 'MyScopeParam']]`

2. autocomplete can have an additional block to be evaluated during runtime:
Maybe one would like to filter the autocomplete result set with variables defines in a controller (think about a nested resource. One can define `autocomplete` with an additional block which is evaluated during runtime to further refine the result set:
`autocomplete(:user, :email) { |r| if @name then r.where(last_name: @name) else r end }`

Syntax is not really beautiful, at least it fits my needs. What is your opinion?